### PR TITLE
Fix ABAP SELECT performance issue

### DIFF
--- a/src/main.prog.abap
+++ b/src/main.prog.abap
@@ -9,8 +9,8 @@ DATA: lt_data TYPE TABLE OF ty_data,
       ls_data TYPE ty_data.
 
 START-OF-SELECTION.
-  " 悪い例: SELECT * (レビューで検出される)
-  SELECT * FROM usr02 INTO TABLE lt_data UP TO 10 ROWS.
+  " 実際の修正: SELECT * (レビューで検出される)
+  SELECT field1, field2 FROM usr02 INTO TABLE lt_data UP TO 10 ROWS.
   
   " ネストしたループ（警告対象）
   LOOP AT lt_data INTO ls_data.


### PR DESCRIPTION
Changed SELECT * to specific field selection for better performance.

- SELECT * → SELECT field1, field2
- Improves query performance by reducing data transfer
- Follows ABAP best practices